### PR TITLE
[FIX] 댓글 조회 시큐리티 수정

### DIFF
--- a/src/main/java/com/rhkr8521/mapping/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/rhkr8521/mapping/common/config/security/SecurityConfig.java
@@ -57,7 +57,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers( "/api-doc", "/health","/v3/api-docs/**", "/swagger-resources/**","/swagger-ui/**", "/h2-console/**").permitAll() // 스웨거, H2콘솔
                         .requestMatchers( "/api/v2/memo/total", "/api/v2/memo/detail").permitAll() // 메모 조회 관련 API
-                        .requestMatchers( "/api/v2/comment").permitAll() // 댓글 조회 관련 API
+                        .requestMatchers(HttpMethod.GET, "/api/v2/comment/**").permitAll() // 댓글 조회 관련 API
                         .requestMatchers("/oauth2/authorization/kakao", "/api/v2/member/accesstoken", "/api/v2/member/login", "/api/v2/member/token-reissue").permitAll() //로그인 관련 API 미인증 접근 가능
                         .anyRequest().authenticated() // 위의 경로 이외에는 모두 인증된 사용자만 접근 가능
                 )


### PR DESCRIPTION
스프링 시큐리티 수정을 통해 댓글 조회 API 인증 불필요 로직 등록하였습니다.